### PR TITLE
Switch to `aws_s3_bucket_acl` resource due to aws provider upgrade to v4

### DIFF
--- a/aws/github-terraform-ci/main.tf
+++ b/aws/github-terraform-ci/main.tf
@@ -53,8 +53,12 @@ module "aws" {
 # In this getting started, we use the same bucket for them.
 resource "aws_s3_bucket" "tfaction" {
   bucket        = local.s3_bucket_name
-  acl           = "private"
   force_destroy = true
+}
+  
+resource "aws_s3_bucket_acl" "tfaction" {
+  bucket = aws_s3_bucket.tfaction.id
+  acl    = "private"
 }
 
 resource "aws_s3_bucket_public_access_block" "tfaction" {


### PR DESCRIPTION
I am trying to do `tfaction-getting-started`.
When doing `terraform plan` for the first time, the following error occurred.

> Error: Value for unconfigurable attribute
> │    55:   acl    = "private"
> │ 
> │ Can't configure a value for "acl": its value will be decided automatically
> │ based on the result of applying this configuration.

So, I switched Terraform configuration to the [aws_s3_bucket_acl resource](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) instead.
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade#acl-argument