### PR TITLE
make status-check job to work with its comment

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -123,6 +123,8 @@ jobs:
   status-check:
     runs-on: ubuntu-latest
     needs: [terraform-plan, tfmigrate-plan, setup]
-    if: failure()
+    if: ${{ always() }}
     steps:
-      - run: exit 1
+      - if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1
+      - run: echo 'success'


### PR DESCRIPTION
There are some cases that `status-check` job doesn't run, so the job is not fitting with a branch protection rule.

This PR try to do following:
- `status-check` job will run even `terraform-plan` or `tfmigrate-plan` is skipped.
- `status-check` job will fail only when at least one of `[terraform-plan, tfmigrate-plan, setup]` jobs.